### PR TITLE
Django 1.10 support

### DIFF
--- a/oauth_provider/compat.py
+++ b/oauth_provider/compat.py
@@ -4,9 +4,9 @@ import django
 # location of patterns, url, include changes in 1.4 onwards
 
 try:
-    from django.conf.urls import patterns, url, include
+    from django.conf.urls import url, include
 except ImportError:
-    from django.conf.urls.defaults import patterns, url, include
+    from django.conf.urls.defaults import url, include
 
 
 # in Django>=1.5 CustomUser models can be specified

--- a/oauth_provider/runtests/urls.py
+++ b/oauth_provider/runtests/urls.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-from oauth_provider.compat import url, patterns, include
+from oauth_provider.compat import url, include
 from oauth_provider.decorators import oauth_required
 from oauth_provider.views import protected_resource_example
 
@@ -13,9 +13,9 @@ def resource_None_scope_view(request):
     return HttpResponse()
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^oauth/', include('oauth_provider.urls')),
     url(r'^oauth/photo/$', protected_resource_example, name='oauth_example'),
     url(r'^oauth/some/$', resource_some_scope_view, name='oauth_resource_some_scope'),
     url(r'^oauth/none/$', resource_None_scope_view, name='oauth_resource_None_scope'),
-)
+]

--- a/oauth_provider/tests/xauth.py
+++ b/oauth_provider/tests/xauth.py
@@ -3,7 +3,6 @@ import time
 import urllib
 from urlparse import parse_qs
 
-from oauth_provider.models import Scope
 from oauth_provider.tests.auth import BaseOAuthTestCase, METHOD_URL_QUERY, METHOD_AUTHORIZATION_HEADER, METHOD_POST_REQUEST_BODY
 
 

--- a/oauth_provider/urls.py
+++ b/oauth_provider/urls.py
@@ -1,9 +1,9 @@
-from oauth_provider.compat import url, patterns, include
+from oauth_provider.compat import url
 
 from views import request_token, user_authorization, access_token
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^request_token/$',    request_token,      name='oauth_request_token'),
     url(r'^authorize/$',        user_authorization, name='oauth_user_authorization'),
     url(r'^access_token/$',     access_token,       name='oauth_access_token'),
-)
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
 
-envlist = py2.7-django1.9,
+envlist = py2.7-django1.10.
+          py2.7-django1.9,
           py2.7-django1.8,
           py2.7-django1.7,
           py2.7-django1.6,
@@ -16,6 +17,10 @@ envlist = py2.7-django1.9,
 
 [testenv]
 commands={envpython} oauth_provider/runtests/runtests.py
+
+[testenv:py2.7-django1.10]
+basepython = python2.7
+deps = django==1.10.3
 
 [testenv:py2.7-django1.9]
 basepython = python2.7


### PR DESCRIPTION
Django 1.10 support.
Remove the use of `url.patterns` and move the regular list for urls. Also added tox for django 1.10.